### PR TITLE
Fix remaining integration tests issues

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -100,10 +100,9 @@ jobs:
         PULSAR_SERVICE_URL: pulsar://localhost:6650
         PULSAR_ADMIN_URL: http://localhost:8081
         TOXIPROXY_URL: http://localhost:8475
-      timeout-minutes: 15  # Reduced from 20 due to parallelism
+      timeout-minutes: 20  # Reduced from 20 due to parallelism
       run: |
-        # Run most tests in parallel
-        swift test --filter PulsarClientIntegrationTests --parallel --num-workers 4
+        swift test --filter PulsarClientIntegrationTests --no-parallel
     
     - name: Cleanup
       if: always()

--- a/Tests/PulsarClientIntegrationTests/ConsumerIntegrationTests.swift
+++ b/Tests/PulsarClientIntegrationTests/ConsumerIntegrationTests.swift
@@ -29,10 +29,12 @@ class ConsumerIntegrationTests {
             throw IntegrationTestError.clientNotInitialized
         }
         
+        let testId = UUID().uuidString.prefix(8)
+        
         // Test Exclusive subscription
         let exclusiveConsumer = try await client.newConsumer(topic: topic, schema: Schema<String>.string) { builder in
             _ = builder
-                .subscriptionName("exclusive-sub")
+                .subscriptionName("exclusive-sub-\(testId)")
                 .subscriptionType(.exclusive)
         }
         
@@ -40,7 +42,7 @@ class ConsumerIntegrationTests {
         await #expect(throws: Error.self) {
             try await client.newConsumer(topic: topic, schema: Schema<String>.string) { builder in
                 _ = builder
-                    .subscriptionName("exclusive-sub")
+                    .subscriptionName("exclusive-sub-\(testId)")
                     .subscriptionType(.exclusive)
             }
         }
@@ -50,13 +52,13 @@ class ConsumerIntegrationTests {
         // Test Shared subscription
         let sharedConsumer1 = try await client.newConsumer(topic: topic, schema: Schema<String>.string) { builder in
             _ = builder
-                .subscriptionName("shared-sub")
+                .subscriptionName("shared-sub-\(testId)")
                 .subscriptionType(.shared)
         }
         
         let sharedConsumer2 = try await client.newConsumer(topic: topic, schema: Schema<String>.string) { builder in
             _ = builder
-                .subscriptionName("shared-sub")
+                .subscriptionName("shared-sub-\(testId)")
                 .subscriptionType(.shared)
         }
 
@@ -75,11 +77,12 @@ class ConsumerIntegrationTests {
             throw IntegrationTestError.clientNotInitialized
         }
         
+        let testId = UUID().uuidString.prefix(8)
         let producer = try await client.newStringProducer(topic: topic)
         
         let consumer = try await client.newConsumer(topic: topic, schema: Schema<String>.string) { builder in
             _ = builder
-                .subscriptionName("ack-sub")
+                .subscriptionName("ack-sub-\(testId)")
                 .initialPosition(.earliest)
         }
         
@@ -97,7 +100,7 @@ class ConsumerIntegrationTests {
         
         let consumer2 = try await client.newConsumer(topic: topic, schema: Schema<String>.string) { builder in
             _ = builder
-                .subscriptionName("ack-sub")
+                .subscriptionName("ack-sub-\(testId)")
         }
         
         // Should receive unacknowledged message again

--- a/Tests/PulsarClientIntegrationTests/IntegrationTestCase.swift
+++ b/Tests/PulsarClientIntegrationTests/IntegrationTestCase.swift
@@ -124,6 +124,10 @@ actor IntegrationTestCase {
     
     func cleanup() async {
         print("[CI-Cleanup] Starting cleanup process.")
+        
+        // Wait a bit to ensure all test operations complete
+        try? await Task.sleep(nanoseconds: 500_000_000) // 0.5 seconds
+        
         // Close client
         if let client = _client {
             print("[CI-Cleanup] Disposing PulsarClient.")

--- a/Tests/PulsarClientIntegrationTests/IntegrationTestCase.swift
+++ b/Tests/PulsarClientIntegrationTests/IntegrationTestCase.swift
@@ -125,8 +125,8 @@ actor IntegrationTestCase {
     func cleanup() async {
         print("[CI-Cleanup] Starting cleanup process.")
         
-        // Wait a bit to ensure all test operations complete
-        try? await Task.sleep(nanoseconds: 500_000_000) // 0.5 seconds
+        // Wait a bit longer to ensure all test operations complete
+        try? await Task.sleep(nanoseconds: 1_000_000_000) // 1 second
         
         // Close client
         if let client = _client {

--- a/Tests/PulsarClientIntegrationTests/ProducerIntegrationTests.swift
+++ b/Tests/PulsarClientIntegrationTests/ProducerIntegrationTests.swift
@@ -33,7 +33,8 @@ class ProducerIntegrationTests {
         let producer = try await client.newStringProducer(topic: topic)
         
         // Create consumer
-        let consumer = try await client.newStringConsumer(topic: topic, subscription: "test-sub")
+        let testId = UUID().uuidString.prefix(8)
+        let consumer = try await client.newStringConsumer(topic: topic, subscription: "test-sub-\(testId)")
         
         // Send message
         let messageContent = "Hello, Pulsar!"
@@ -68,7 +69,8 @@ class ProducerIntegrationTests {
                 .batchingMaxDelay(0.1)
         }
         
-        let consumer = try await client.newStringConsumer(topic: topic, subscription: "batch-sub")
+        let testId = UUID().uuidString.prefix(8)
+        let consumer = try await client.newStringConsumer(topic: topic, subscription: "batch-sub-\(testId)")
         
         // Send batch of messages
         let messages = (0..<10).map { "Message \($0)" }

--- a/Tests/PulsarClientIntegrationTests/RawFrameTest.swift
+++ b/Tests/PulsarClientIntegrationTests/RawFrameTest.swift
@@ -51,6 +51,6 @@ class RawFrameTest {
         
         // Cleanup
         await producer.dispose()
-        await client.dispose()
+        // Don't dispose client here - it's handled by IntegrationTestCase
     }
 }


### PR DESCRIPTION
This simple PR aims to fix any remaining issues that cause the Integration tests to throw errors or hang forever in the local and/or GitHub Actions testing environments.