### PR TITLE
Bump Swift version to 6.2

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 6.1
+// swift-tools-version: 6.2
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
@@ -28,7 +28,9 @@ let package = Package(
         .package(url: "https://github.com/edgeengineer/cyclic-redundancy-check.git", from: "0.0.5"),
         // Telemetry dependencies
         .package(url: "https://github.com/apple/swift-metrics.git", from: "2.4.0"),
-        .package(url: "https://github.com/apple/swift-distributed-tracing.git", from: "1.1.0")
+        .package(url: "https://github.com/apple/swift-distributed-tracing.git", from: "1.1.0"),
+        // Testing dependency
+        .package(url: "https://github.com/apple/swift-testing.git", from: "0.12.0")
     ],
     targets: [
         // Targets are the basic building blocks of a package, defining a module or a test suite.
@@ -51,11 +53,17 @@ let package = Package(
         ),
         .testTarget(
             name: "PulsarClientTests",
-            dependencies: ["PulsarClient"]
+            dependencies: [
+                "PulsarClient",
+                .product(name: "Testing", package: "swift-testing")
+            ]
         ),
         .testTarget(
             name: "PulsarClientIntegrationTests",
-            dependencies: ["PulsarClient"]
+            dependencies: [
+                "PulsarClient",
+                .product(name: "Testing", package: "swift-testing")
+            ]
         ),
     ],
     swiftLanguageModes: [.v6]

--- a/Samples/Package.swift
+++ b/Samples/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 6.0
+// swift-tools-version: 6.2
 import PackageDescription
 
 let package = Package(

--- a/Sources/PulsarClient/Internal/ChannelManager+Handlers.swift
+++ b/Sources/PulsarClient/Internal/ChannelManager+Handlers.swift
@@ -131,7 +131,7 @@ extension ConsumerChannel {
     var isActive: Bool = true
   }
 
-  private static var messageStates: [UInt64: MessageState] = [:]
+  nonisolated(unsafe) private static var messageStates: [UInt64: MessageState] = [:]
 
   /// Handle incoming message
   func handleMessage(

--- a/Sources/PulsarClient/PulsarProtocol.swift
+++ b/Sources/PulsarClient/PulsarProtocol.swift
@@ -38,10 +38,7 @@ public struct PulsarFrame: Sendable {
     do {
       commandData = try command.serializedData()
     } catch {
-      print("ERROR: Failed to serialize command: \(error)")
-      print("Command type: \(command.type)")
-      print("Command details: \(command)")
-      fatalError("Failed to serialize command: \(error)")
+      fatalError("Failed to serialize command (\(command.type)): \(error)")
     }
     self.commandSize = UInt32(commandData.count)
 
@@ -52,14 +49,6 @@ public struct PulsarFrame: Sendable {
         let metadataData = try metadata.serializedData()
         totalSize += UInt32(metadataData.count) + 4  // 4 bytes for metadata size + metadata data
       } catch {
-        print("ERROR: Failed to serialize metadata: \(error)")
-        print("Metadata details:")
-        print(
-          "  hasProducerName: \(metadata.hasProducerName), producerName: '\(metadata.producerName)'"
-        )
-        print("  hasSequenceID: \(metadata.hasSequenceID), sequenceID: \(metadata.sequenceID)")
-        print("  hasPublishTime: \(metadata.hasPublishTime), publishTime: \(metadata.publishTime)")
-        print("  compression: \(metadata.compression)")
         fatalError("Failed to serialize metadata: \(error)")
       }
     }
@@ -104,13 +93,6 @@ public struct PulsarFrameEncoder {
     do {
       metadataData = try metadata.serializedData()
     } catch {
-      print("ERROR: Failed to serialize metadata in encoder: \(error)")
-      print("Metadata details:")
-      print(
-        "  hasProducerName: \(metadata.hasProducerName), producerName: '\(metadata.producerName)'")
-      print("  hasSequenceID: \(metadata.hasSequenceID), sequenceID: \(metadata.sequenceID)")
-      print("  hasPublishTime: \(metadata.hasPublishTime), publishTime: \(metadata.publishTime)")
-      print("  compression: \(metadata.compression)")
       fatalError("Failed to serialize metadata in encoder: \(error)")
     }
     let metadataSize = UInt32(metadataData.count)


### PR DESCRIPTION
This small PR aims to bump the Swift version of the Pulsar client to the latest version (6.2.3) and removes some leftover debug logging from prior fixes.